### PR TITLE
Change queues onClick

### DIFF
--- a/src/components/artist/ArtistPopular.tsx
+++ b/src/components/artist/ArtistPopular.tsx
@@ -1,10 +1,8 @@
-import { SongRow } from "@spotify/components/playlist/PlaylistSongRow";
 import { trpc } from "@spotify/utils";
 import { useStoreState } from "@spotify/utils/state";
 import { SongModel } from "@spotify/utils/state/stateModel";
 import { useEffect } from "react";
 import { PlayPauseButton } from "../shared";
-import { Button } from "../shared/Utils/Button";
 import { ButtonWithOptimisticUpdate } from "../shared/Utils/ButtonWithOptimisticUpdate";
 import { SongRowWrapper } from "@spotify/components/shared/Wrappers/SongWrapper";
 
@@ -54,6 +52,12 @@ export const ArtistPopular: React.FC<{
     })
     .flat();
 
+  useEffect(() => {
+    console.log(
+      `ArtistPopular coming from ${id}: Getting new active queue: `,
+      newActiveQueue
+    );
+  }, [newActiveQueue, id]);
   return (
     <div>
       <div className="flex space-x-5 mb-5">
@@ -63,6 +67,7 @@ export const ArtistPopular: React.FC<{
           shouldChangeActiveSong={(activeSong) => {
             return activeSong?.Album.Artist.id === id ? false : true;
           }}
+          id="artist-popular-play-button"
         />
         <ButtonWithOptimisticUpdate
           action={`${isFavoriteArtist ? "unfollowed" : "followed"} ${

--- a/src/components/shared/Cards/AlbumCard.tsx
+++ b/src/components/shared/Cards/AlbumCard.tsx
@@ -24,7 +24,6 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
   );
 
   function onPlay() {
-    console.log("AlbumCard: refetching songs");
     refetch().then((d) => console.log(d));
   }
 
@@ -62,6 +61,12 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
       imgSrc={img}
       href={`/app/album/${id}`}
       newActiveQueue={getNewActiveQeue(songs)}
+      shouldChangeActiveSong={(activeSong) => {
+        if (activeSong.Album.id !== id) {
+          return true;
+        }
+        return false;
+      }}
       onPlay={onPlay}
       rounded={false}
     />

--- a/src/components/shared/Wrappers/SongWrapper.tsx
+++ b/src/components/shared/Wrappers/SongWrapper.tsx
@@ -8,8 +8,6 @@ import {
   IDXColumn,
   TrackInfoColumn,
 } from "@spotify/components/playlist/PlaylistTableColumns";
-import { useFavoriteSong } from "@spotify/utils/hooks/useFavorite";
-import { FavoriteButton } from "@spotify/components/shared/FavoriteButton";
 
 export const SongRowWrapper: React.FC<
   SongRowProps & { isLoading?: boolean }
@@ -88,9 +86,6 @@ const SongRowWrapperContent: React.FC<SongRowProps> = (p) => {
     }
   };
 
-  const activeSong = useStoreState((state) => state.activeSong);
-
-  useEffect(() => console.log("active: ", activeSong), [activeSong]);
   return (
     <div
       className="relative w-full flex justify-between h-12 items-center fill-zinc-400 text-sm text-zinc-400 hover:bg-zinc-700 hover:bg-opacity-50 rounded-md flex-wrap px-2"

--- a/src/utils/typeGaurds.ts
+++ b/src/utils/typeGaurds.ts
@@ -12,3 +12,20 @@ export function assertIsValidId(id: string | string[] | undefined) {
     throw new Error(`Wrong id, expected string, got ${typeof id}`);
   }
 }
+
+export function isStrictlyString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isStrictEqualArray<T>(a1: T[], a2: T[]) {
+  if (a1.length !== a2.length) {
+    console.log("isStrictEqualArray: Arrays are not the same length");
+    return false;
+  }
+  for (let i = 0; i < a1.length; i++) {
+    if (JSON.stringify(a1[i]) !== JSON.stringify(a2[i])) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
# Requirement:
The song queue should globally change depending on the which card the user clicks on

# Solution:
- Create a unified way to handle new upcoming queues using `PlayPauseButton`.
- Fetch the new songs that will be added to the queue on-demand
- Handle changes of the queues 
- Reflect the active queue in the UI, for example, in here, both the player controls in the bottom and the play button at the top of the page should be in the playing state because the active song belogs to that queue 
![example](https://uploads.linear.app/15050a10-000e-4aaf-98c2-ddafe6149a9b/b64dc71c-7055-44be-86c1-35c19ece5a6e/d87d058c-d819-4b6e-949d-314ba41f387e)
